### PR TITLE
Packaging info, DMA buffer workaround, and SBC list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ Please report any problems running pre-compiled libraries from this repository d
  - `sources` - reference source code used for building the binaries. Uses git submodules to reference to the relevant git repositories. See *Manual Compilation* for more details.
  - `firmware` - FPGA images for reflashing. (not yet published)
 
+## Pre-built packages
 
+ - [Alpine Linux](https://github.com/aports-ugly/aports/tree/master/ugly/libxtrx)
+ - [Arch Linux](https://aur.archlinux.org/packages/?K=xtrx)
+ - [openSUSE](https://build.opensuse.org/repositories/hardware:sdr)
+ - [Ubuntu 18.04](https://github.com/satunnainen/images/tree/master/binaries/Ubuntu_18.04_amd64)
 
 ## Manual compilation of host libraries from the `sources` directory
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,33 @@ If you see output similar to the one above, XTRX is ready to rock! And you can n
 3. XTRX is blinking with ON-OFF-OFF-OFF-ON-OFF-OFF-OFF pattern. It means XTRX hasn't been enumerated on PCIe bus. Try to use other PCIe or miniPCIe slot if available. Please contact <xtrx@fairwaves.co> with details of you installation and system details for future assistance.
 4. In all other cases fell free to contact us <xtrx@fairwaves.co>
 
+## Which boards/laptop could you advice to use them with XTRX?
+Generally your board should have the miniPCIe socket (obviously) with the PCI lane. Most of laptops wouldn't work, since generally they have PCI lane only on half-sized miniPCIe sockets (used for WiFi devices) while full-sized sockets designed mostly for using with SATA and USB lanes only. Industrial SBCs frequently have at least one such socket thus are more suitable for XTRX.
+
+Here is list of devices which was actually tested by us and our customers and definitely works with XTRX:
+ - [UpSquared](https://up-board.org/upsquared/specifications/) by UpBoard
+ - [Jetson TK1](https://www.nvidia.com/object/jetson-tk1-embedded-dev-kit.html) by NVidia
+ - various devices by [LEX](http://www.lex.com.tw/), specifically [TERA + 2I610DW](http://www.lex.com.tw/products/TERA-2I610DW.html) and [3I610CW](http://www.lex.com.tw/products/3I610CW.html)
+ - various SBCs by [PC Engines](https://www.pcengines.ch/), specifically [apu1d4](https://www.pcengines.ch/apu1d4.htm), [apu2d4](https://pcengines.ch/apu2d4.htm), and [apu4b4](https://www.pcengines.ch/apu4b4.htm) (may be suitable for 1 XTRX only, check the specs)
+ - [Newport GW6300](http://www.gateworks.com/product/item/newport-gw6300-single-board-computer) by GATEWORKS
+ - [ROCKPro64](https://www.pine64.org/rockpro64/) by Pine64
+ - [IPC3](https://www.fit-pc.com/web/products/ipc3/) by fit-PC
+ - [ARTiGO A1200](https://www.viatech.com/en/support/eol/artigo-a1200-eol/) by VIA (see #28)
+
+SBCs that most likely would work with XTRX still wasn't actually tested:
+ - various SBCs by [AAEON](https://www.aaeon.com/en/c/embedded-single-board-computers/)
+ - various SBCs by [Advantech devices](https://www.advantech.com/products/embedded-single-board-computers/sub_c427052f-f55f-4d47-9a84-3a11ed5295df)
+ - various devices by [Logic Supply](https://www.logicsupply.com/)
+ - [MPT-7000V](https://www.ibase.com.tw/english/ProductDetail/IntelligentTransportation/MPT-7000V) by IBASE; suitable for 1 XTRX only
+ - [Nuvo-5100VTC](https://www.neousys-tech.com/en/product/application/in-vehicle-computing/nuvo-5100vtc); seems suitable for 2 XTRX (4 miniPCIe sockets, 2 of them supports USB signals only)
+ - [ECS-9110](http://www.vecow.com/dispPageBox/vecow/VecowCT.aspx?ddsPageID=PRODUCTDTL_EN&dbid=4357925395) by Vecow most likely would work
+ - [EC500-KH](https://www.dfi.com/Product/Index/1412) and [EC70B-SU](https://www.dfi.com/Product/Index/125) by DFI most likely would work
+ - some older versions of Intel NUC which have miniPCIe may work
+ - most likely Dell Latitide D420 would work; it have full-sized miniPCIe (used for WiFi by default) and no PCI whitelist in BIOS
+ - some outdated EeePCs like 901 and 701 by asus may work (assuming based on the same premises as for Dell Latitude D420)
+ - any device with full-featured PCIe x2 socket or USB3+ receptacle in case you use XTRX with PCIe x2 Front End or USB 3 Adapter respectively (see [CrowdSupply page](https://www.crowdsupply.com/fairwaves/xtrx) for details and order)
+You can also check other SBCs by mentioned vendors.
+
 ## XTRX installed into miniPCIe slot prevents the system from booting (don't get even to BIOS)
 This problem can happen if your motherboard provide SMB signals to miniPCIe connector. Most system doesn't. The XTRX rev.4 use reseved pins that are held in hi-Z. However, during the startup DC/DC chip isn't initialized and XTRX actually pulling down the SMB DATA line that mostly connected to critical to boot chips. We're working on firmware fix but currently hardware modification (cutting the fuse on the bottom side of xtrx near the edge) is the only solution.
 Cut the fuse with a sharp knife. Make sure not to use much pressure since you can accidently cut other traces.

--- a/README.md
+++ b/README.md
@@ -172,4 +172,10 @@ Unfortunatly USB2 PHY software isn't ready and wasn't pushed in the master. You 
 ## Is Windows driver support planned?
 We plan to add Windows PCIe drivers but we don't have specific schedule for this right now. If it's blocking factor please contact us <xtrx@fairwaves.co>. However, all other software layers are windows compatible and USB3380 adapter should work via WinUSB.
 
-
+## I've got a DMA buffer issue on my ARM device
+You should probably increase DMA coherent pool using `coherent_pool=32M` kernel option in case you see following lines in the `dmesg` output:
+```
+[ 7.171608] xtrx: Failed to allocate 31 DMA buffer
+[ 7.171632] xtrx 0000:01:00.0: Failed to register TX DMA buffers.
+```
+For the details see issue #37.


### PR DESCRIPTION
Updates for `readme`:
- added links to packages for various distros
- added  workaround suggestion for DMA buffer issue
- added SBC list to use with XTRX