### PR TITLE
remove LMS7002M-driver from .gitmodules configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "sources/libxtrxdsp"]
 	path = sources/libxtrxdsp
 	url = https://github.com/xtrx-sdr/libxtrxdsp
-[submodule "sources/LMS7002M-driver"]
-	path = sources/LMS7002M-driver
-	url = https://github.com/xtrx-sdr/LMS7002M-driver
 [submodule "sources/xtrx_linux_pcie_drv"]
 	path = sources/xtrx_linux_pcie_drv
 	url = https://github.com/xtrx-sdr/xtrx_linux_pcie_drv


### PR DESCRIPTION
Submodule gitlink was already removed in 884ac50f56f77f3ae07ffa5325da183477b5ebd7.

Background:
Some build systems seem to have trouble with sorting this out. For me a Flatpak build failed with version 1.4.0 - and it likely works due to a related fix in followup version 1.4.1. However doesn't hurt to do things right. :)