### PR TITLE
ppa for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please report any problems running pre-compiled libraries from this repository d
  - [Alpine Linux](https://github.com/aports-ugly/aports/tree/master/ugly/libxtrx)
  - [Arch Linux](https://aur.archlinux.org/packages/?K=xtrx)
  - [openSUSE](https://build.opensuse.org/repositories/hardware:sdr)
- - [Ubuntu 18.04](https://github.com/satunnainen/images/tree/master/binaries/Ubuntu_18.04_amd64)
+ - [Ubuntu 18.04](https://launchpad.net/~fairwaves/+archive/ubuntu/xtrx)
 
 ## Manual compilation of host libraries from the `sources` directory
 


### PR DESCRIPTION
replaced link to binary packages with ppa for ubuntu